### PR TITLE
Add github actions to check release and update changelog

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Onfido
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# changelog-action
+# Onfido Github Actions
+
+Set of reusable workflows used by Onfido Github actions.

--- a/release-check/action.yml
+++ b/release-check/action.yml
@@ -1,0 +1,17 @@
+name: Check release
+description: Check release information before delivery
+runs:
+  using: "composite"
+  steps:
+
+    - name: Sanity check
+      shell: bash
+      run: |
+        RELEASE_NAME=v3.1.0
+        RELEASE_VERSION=$(jq -r '.release' .release.json)
+
+        if [ "$RELEASE_NAME" != "$RELEASE_VERSION" ]
+        then
+          echo "Expecting release name '$RELEASE_VERSION', but '$RELEASE_NAME' found."
+          exit 1
+        fi

--- a/update-changelog/action.yml
+++ b/update-changelog/action.yml
@@ -1,0 +1,20 @@
+name: Update CHANGELOG.md
+description: Re-usable workflow to update CHANGELOG.md file in libraries' repository
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Update CHANGELOG.md
+      run: ${{ github.action_path }}/update-changelog.sh
+      shell: bash
+      env:
+        RELEASE_BODY: ${{ github.event.release.body }}
+
+    - name: Commit CHANGELOG.md
+      shell: bash
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "<>"
+        git commit -m "Update CHANGELOG.md after library release" CHANGELOG.md
+        git push

--- a/update-changelog/update-changelog.sh
+++ b/update-changelog/update-changelog.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Don't carry on when any command fails
+set -e
+
+TMP_FILE=$(mktemp)
+
+RELEASE_VERSION=$(jq -r '.release' .release.json)
+RELEASE_DATE=`date +'%dth %B %Y' | sed -E 's/^0//;s/^([2,3]?)1th/\11st/;s/^([2]?)2th/\12nd/;s/^([2]?)3th/\13rd/'`
+
+SPEC_COMMIT_SHA=$(jq -r '.source.short_sha' .release.json)
+SPEC_COMMIT_URL=$(jq -r '.source.repo_url + "/commit/" + .source.long_sha' .release.json)
+SPEC_RELEASE_VERSION=$(jq -r '.source.version' .release.json)
+SPEC_RELEASE_URL=$(jq -r '.source.repo_url + "/releases/tag/" + .source.version' .release.json)
+
+# Changelog header
+echo -e "# Changelog\n\n## $RELEASE_VERSION $RELEASE_DATE\n" >| $TMP_FILE
+
+# Onfido OpenAPI reference release (or commit)
+echo -en " - Release based on Onfido OpenAPI spec " >> $TMP_FILE
+
+if [ -z $SPEC_RELEASE_VERSION ]; then
+  echo "up to commit [$SPEC_COMMIT_SHA](${SPEC_COMMIT_URL})." >> $TMP_FILE
+else
+  echo "version [$SPEC_RELEASE_VERSION](${SPEC_RELEASE_URL})." >> $TMP_FILE
+fi
+
+# Add and format contents from github release notes body (lines starting with - only)
+cat <<EOF | grep '^ *-' | sed 's/^ *- */ - /' >> $TMP_FILE || true
+$RELEASE_BODY
+EOF
+
+# Add contents from previous changelog and override it
+grep -v "^# Changelog" CHANGELOG.md >> $TMP_FILE
+mv $TMP_FILE CHANGELOG.md


### PR DESCRIPTION
This change is for adding two actions for being used by client libraries at release time as [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow):
- `release-check`: check that version in github release matches the one used in the library
- `update-changelog`: update CHANGELOG.md with contents from github release

[This PR](https://github.com/onfido/onfido-python/pull/64) has been created to show that in action. And the results below, from [this](https://github.com/onfido/onfido-python/actions/runs/9676267448/job/26695831417) adjusted execution, to show the change without performing a release for now:

```markdown
# Changelog

## v3.1.0 26th June 2024

 - Release based on Onfido OpenAPI spec version [v3.0.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v3.0.0).
 - new endpoint bla bla (test) 
 - Integration tests have also been implemented

## v3.1.0 24th June 2024
``` 

Above change has been automatically generated from text below (set as PR description, by keeping only lines starting with `-`):
```markdown
## What's Changed (DEMO)
 - new endpoint bla bla (test) 
 - Integration tests have also been implemented
   * test: add tests for onfido-python library by @sofia-gomes-onfido in https://github.com/onfido/onfido-python/pull/54
   * Tests id_photos endpoints by @andremendes2 in https://github.com/onfido/onfido-python/pull/58
   * test: add timeline file and webhook tests by @sofia-gomes-onfido in https://github.com/onfido/onfido-python/pull/59

## New Contributors
* @sofia-gomes-onfido made their first contribution in https://github.com/onfido/onfido-python/pull/54
* @andremendes2 made their first contribution in https://github.com/onfido/onfido-python/pull/58

**Full Changelog**: https://github.com/onfido/onfido-python/compare/v2.10.1...v3.1.0 (including pre-release v3.0.0)
```

[These changes](https://github.com/onfido/onfido-python/pull/64/files) will be needed to enable these actions in any onfido-* client library repository.